### PR TITLE
Fix inversion timing to occur on SCS falling edge

### DIFF
--- a/src/pico_env_mon.cpp
+++ b/src/pico_env_mon.cpp
@@ -87,7 +87,6 @@ int main() {
 
         // LCD update
         lcd.write(screen.data);
-        lcd.toggle_com();
     }
 }
 


### PR DESCRIPTION
Thank you very much for publishing this project! It's great! ほんとに,ありがと！

But I was working on ways to improve power consumption and found the way you're driving the `EXTCOMIN` pin doesn't seem to match what the datasheet expects? I assume this is accidental? (I don't think the datasheet explains it very well)

Previously `EXTCOMIN` was toggled either `high` or `low` after `lcd.write()` when `SCS` was `low` every 500 ms. This fix makes a rising edge on `EXTCOMIN`, when `SCS` is `high` during `lcd.write()` every 500 ms in preparation of `SCS` falling edge where COM inversion takes place.

What the datasheet wants in section "6-5-5 COM Inversion":
<img width="1235" alt="extcomin-rising-edge-timing" src="https://github.com/shapoco/pico-env-mon/assets/43670403/64740ecf-6fee-4ea0-8123-02ae99549173">

Behavior of this new fix:
![scope_7](https://github.com/shapoco/pico-env-mon/assets/43670403/bc9e8920-4492-4468-a6cb-78124cfe2752)


Development circuit:
![A7C03610](https://github.com/shapoco/pico-env-mon/assets/43670403/f87b23b3-f2d4-4693-aedc-0e7a7cfb209b)

Also I'll mention the above development circuit uses an MH-Z14A instead of a MH-Z19C and LS027B7DH01 instead of a LS027B4DH01 (no code modifications required).